### PR TITLE
Fix telescoping searching to ignore .log files

### DIFF
--- a/nvim/lua/watts/plugins/telescope.lua
+++ b/nvim/lua/watts/plugins/telescope.lua
@@ -52,7 +52,7 @@ return {
             "%.csv",
             "public/assets",
             "public/downloads",
-            "log",
+            "%.log",
           },
         },
       })


### PR DESCRIPTION
"log" was removing all files that had `log` in the filename :facepalm: